### PR TITLE
`Add top navigation bar linking to Docs, Learn, Templates, and Deploy pages`

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Image from 'next/image'
 import { Inter } from 'next/font/google'
 import styles from '@/styles/Home.module.css'
+import Link from 'next/link'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -14,6 +15,30 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/docs">
+              <a>Docs</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/learn">
+              <a>Learn</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/templates">
+              <a>Templates</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/deploy">
+              <a>Deploy</a>
+            </Link>
+          </li>
+        </ul>
+      </nav>
       <main className={styles.main}>
         <div className={styles.description}>
           <p>


### PR DESCRIPTION
This pull request adds a top navigation bar to the website that links to the Docs, Learn, Templates, and Deploy pages. The navigation bar is located at the top of the page and is visible on all pages of the website. This will make it easier for users to navigate to different sections of the website and find the information they need. The navigation bar is responsive and will adjust to different screen sizes.